### PR TITLE
feat(tap-to-scroll): add an option to scroll when user taps on Viewer

### DIFF
--- a/Shinsi2/Const.swift
+++ b/Shinsi2/Const.swift
@@ -33,6 +33,8 @@ let kUDViewerMode = "kUDViewerMode"
 let kUDViewerReadDirection = "kUDViewerReadDirection"
 let kUDViewerReloadData = "kUDViewerReloadData"
 
+let kUDViewerTapToScroll = "kUDViewerTapToScroll"
+
 //Color
 let kMainColor = UIApplication.shared.keyWindow?.tintColor ?? #colorLiteral(red: 0.8459790349, green: 0.2873021364, blue: 0.2579272389, alpha: 1)
 
@@ -112,6 +114,10 @@ class Defaults {
         static var readDirection : ViewerVC.ViewerReadDirection{
             get { return ViewerVC.ViewerReadDirection(rawValue: UserDefaults.standard.integer(forKey: kUDViewerReadDirection))!}
             set {UserDefaults.standard.set(newValue.rawValue, forKey: kUDViewerReadDirection)}
+        }
+        static var tapToScroll : Bool {
+            get { return UserDefaults.standard.bool(forKey: kUDViewerTapToScroll)}
+            set { UserDefaults.standard.setValue(newValue, forKey: kUDViewerTapToScroll)}
         }
     }
     

--- a/Shinsi2/ViewControllers/SettingVC.swift
+++ b/Shinsi2/ViewControllers/SettingVC.swift
@@ -133,6 +133,12 @@ class SettingVC: BaseViewController {
         stackView.addRow(viewerModeSeg)
         stackView.addRow(viewerReadDirectionSeg)
         
+        let tapToScrollLabel = createSubTitleLabel("Tap To Scroll")
+        let tapToScrollSwitch = UISwitch()
+        tapToScrollSwitch.isOn = Defaults.Viewer.tapToScroll
+        tapToScrollSwitch.addTarget(self, action: #selector(viewerTapToScrollValueChanged), for: .valueChanged)
+        stackView.addRow(createStackView([tapToScrollLabel, tapToScrollSwitch]))
+        
         //Cache+
         addTitle("Cache")
         let cacheSizeLable = createSubTitleLabel("size: counting...")
@@ -231,6 +237,10 @@ class SettingVC: BaseViewController {
     
     @objc func viewerReadDirectionSegmentedControlValueChanged(sender:UISegmentedControl){
         Defaults.Viewer.readDirection = sender.selectedSegmentIndex == 0 ? .L2R : .R2L
+    }
+    
+    @objc func viewerTapToScrollValueChanged(sender: UISwitch) {
+        Defaults.Viewer.tapToScroll = sender.isOn
     }
     
     func presentWebViewController(url: URL) {


### PR DESCRIPTION
When the Tap To Scroll setting is turned on, and Scroll Direction is Horizontal:
* If user taps left 1/3 of the screen, scroll left.
* If user taps right 1/3 of the screen, scroll right.
* Do nothing if center 1/3 is tapped.

If Tap To Scroll is disabled, or Scroll Direction is Vertical, tapping will close the view.